### PR TITLE
update documentation related to queryBuilder.sortBy method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ modifier = (queryBuilder, value, build) => {
 #### Tricks
 Even though this plugin is called custom filter, it really opens up a lot of possibilities because you are exposed to the queryBuilder, the key of the queries. You could also sort it with
 ```javascript
-queryBuilder.sortBy(pgSql.query`select name from roles where roles.id = ${queryBuilder.getTableAlias()}.${pgSql.identifier('role_id')}`);
+queryBuilder.orderBy(pgSql.query`(select name from roles where roles.id = ${queryBuilder.getTableAlias()}.${pgSql.identifier('role_id')})`);
 ```
 This will add a sorter to sort it by the role name. Of course you'll remember to not specify other orderBy.
 A full example of sort by nested fields
@@ -161,8 +161,8 @@ const filter = {
       fieldType: 'String',
       modifier: (queryBuilder, value, build) => {
         if (value) {
-          queryBuilder.sortBy(pgSql.query`
-          select name from roles where roles.id = ${queryBuilder.getTableAlias()}.${pgSql.identifier('role_id')}
+          queryBuilder.orderBy(pgSql.query`
+            (select name from roles where roles.id = ${queryBuilder.getTableAlias()}.${pgSql.identifier('role_id')})
           `, true); // true/false means asc/desc
         }
       },


### PR DESCRIPTION
Hi!

I am using your library and I find it very useful to create custom filters.

I created this PR because I found a problem with the current documentation.

I am working with Postgraphile version 4.1.0 and they don't have queryBuilder.sortBy method.

I updated the documentation to use queryBuilder.orderBy instead of sortBy.

I hope that you find this PR useful.

Bye!