### PR TITLE
Tolerate an incorrect `ofType` structure

### DIFF
--- a/src/AddFieldsToCustomFilter.js
+++ b/src/AddFieldsToCustomFilter.js
@@ -198,9 +198,9 @@ module.exports = function AddFieldsToCustomFilter(builder, options) {
         return args;
       }
       const returnName = field.type.ofType ? field.type.ofType.name : field.type.name;
-      // Only add it to the spedified connection
+      // Only add it to the specified connection
       // like 'UsersConnection' (notice it's plural)
-      if (!returnName.endsWith('Connection')) return args;
+      if (!returnName || !returnName.endsWith('Connection')) return args;
       const modelName = pluralize.singular(returnName.substring(0, returnName.length - 10));
       const filterForModel = filters[modelName];
       // Skip it if it's not the right model


### PR DESCRIPTION
Hi, I noticed a minor problem that led to a crash. 
```
TypeError: Cannot read properties of undefined (reading 'ofType')
```
I don't know what causes it, but it looks like some other plugins do not respect the structure of the `ofType` type. (the name was inside of `field.type.ofType.ofType.name`).

So here is a simple fix to make the plugin tolerate it. 
Seems like it solves https://github.com/RoadRunnerEngineering/postgraphile-plugin-custom-filter/issues/4